### PR TITLE
컬럼명 변경 및 추가(created_by_id)

### DIFF
--- a/backend/Dockerfile.backend
+++ b/backend/Dockerfile.backend
@@ -1,9 +1,5 @@
 FROM node:16
 
-ENV DOCKERIZE_VERSION v0.2.0  
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \  
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
 WORKDIR /usr/src/app
 
 COPY package*.json ./
@@ -14,7 +10,4 @@ COPY . .
 
 EXPOSE 5001
 
-RUN chmod +x docker-entrypoint.sh  
-ENTRYPOINT ./docker-entrypoint.sh
-
-# CMD [ "npm", "run", "start:dev:docker" ]
+CMD [ "npm", "run", "start:dev" ]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,4 +1,0 @@
-dockerize -wait tcp://mysql:3306 -timeout 20s
-
-echo "Start nodejs server"
-npm run start:dev

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "start:local": "nodemon",
     "start:dev": "NODE_ENV=development nodemon",
     "start:prod": "npm run build && NODE_ENV=production node dist/src/app.js",
+    "typeorm": "NODE_ENV=development node -r tsconfig-paths/register -r ts-node/register ./node_modules/typeorm/cli.js --dataSource ./src/infra/mysql/dataSource.ts",
     "test": "echo 'Error: no test specified' && exit 1"
   },
   "keywords": [],

--- a/backend/src/controller/article.controller.ts
+++ b/backend/src/controller/article.controller.ts
@@ -27,7 +27,7 @@ class ArticleController {
   public createArticle: RequestHandler<{}, ItemResponse<Article>> = async (req, res) => {
     const article = await this.articleService.createArticle({
       ...req.body,
-      writer_id: req.session.userid,
+      created_by_id: req.session.userid,
     })
 
     res.status(201).json(article)
@@ -39,7 +39,7 @@ class ArticleController {
   ) => {
     const result = await this.articleService.getArticles({
       ...req.query,
-      writer_id: req.session.userid,
+      created_by_id: req.session.userid,
     })
 
     res.status(200).json(result)

--- a/backend/src/controller/taskCard.controller.ts
+++ b/backend/src/controller/taskCard.controller.ts
@@ -18,8 +18,10 @@ class TaskCardController {
   }
 
   public createTaskCard: RequestHandler<{}, ItemResponse<TaskCard>> = async (req, res, next) => {
-    const { name, description } = req.body
-    const taskCard = await this.taskCardService.createTaskCard({ name, description })
+    const taskCard = await this.taskCardService.createTaskCard({
+      ...req.body,
+      created_by_id: req.session.userid,
+    })
 
     if (taskCard) {
       res.status(201).json(taskCard)
@@ -32,7 +34,10 @@ class TaskCardController {
 
   public getTaskCards: RequestHandler<{}, ItemsResponse<TaskCard>, {}, GetTaskCardsReqQuery> =
     async (req, res, next) => {
-      const result = await this.taskCardService.getTaskCards(req.query)
+      const result = await this.taskCardService.getTaskCards({
+        ...req.query,
+        created_by_id: req.session.userid,
+      })
 
       res.status(200).json(result)
     }

--- a/backend/src/domain/article/article.entity.ts
+++ b/backend/src/domain/article/article.entity.ts
@@ -38,16 +38,16 @@ export class Article {
 
   @Column(
     new UuidService().uuidColumnOptions({
-      name: 'writer_id',
+      name: 'created_by_id',
     })
   )
-  writer_id: string
+  created_by_id: string
 
   @ManyToOne(() => User)
   @JoinColumn({
-    name: 'writer_id',
+    name: 'created_by_id',
   })
-  writer: User
+  created_by: User
 
   constructor(
     {
@@ -56,14 +56,14 @@ export class Article {
       thumbnail,
       short_description,
       content,
-      writer_id,
+      created_by_id,
     }: {
       title: string
       content: string
       id?: number
       thumbnail?: string
       short_description?: string
-      writer_id?: string
+      created_by_id?: string
     } = {
       title: '',
       content: '',
@@ -76,7 +76,7 @@ export class Article {
     this.short_description = short_description
 
     if (id) this.id = id
-    if (writer_id) this.writer_id = writer_id
+    if (created_by_id) this.created_by_id = created_by_id
   }
 
   public increaseMyViews(): void {

--- a/backend/src/domain/article/article.repository.ts
+++ b/backend/src/domain/article/article.repository.ts
@@ -3,11 +3,14 @@ import { Article } from './article.entity'
 
 export interface ArticleRepository {
   create(
-    article: Pick<Article, 'title' | 'content' | 'thumbnail' | 'short_description' | 'writer_id'>
+    article: Pick<
+      Article,
+      'title' | 'content' | 'thumbnail' | 'short_description' | 'created_by_id'
+    >
   ): Promise<Article>
   getList(
     option?: Partial<
-      Pick<Article, 'title' | 'content' | 'thumbnail' | 'short_description' | 'writer_id'>
+      Pick<Article, 'title' | 'content' | 'thumbnail' | 'short_description' | 'created_by_id'>
     > &
       PageParam
   ): Promise<Result<Article> | PaginationResult<Article>>

--- a/backend/src/domain/taskCard/taskCard.entity.ts
+++ b/backend/src/domain/taskCard/taskCard.entity.ts
@@ -1,5 +1,15 @@
-import { AfterLoad, Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import {
+  AfterLoad,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm'
 import { Task } from '../task/task.entity'
+import UuidService from 'domain/uuidService'
+import { User } from 'domain/user/user.entity'
 
 @Entity({ database: 'dev_wiki_db', name: 'task_card' })
 export class TaskCard {
@@ -17,6 +27,19 @@ export class TaskCard {
 
   @OneToMany(() => Task, (task) => task.task_card)
   tasks?: Task[]
+
+  @Column(
+    new UuidService().uuidColumnOptions({
+      name: 'created_by_id',
+    })
+  )
+  created_by_id: string
+
+  @ManyToOne(() => User)
+  @JoinColumn({
+    name: 'created_by_id',
+  })
+  created_by: User
 
   total_task_count: number = 0
   completed_task_count: number = 0

--- a/backend/src/domain/taskCard/taskCard.repository.ts
+++ b/backend/src/domain/taskCard/taskCard.repository.ts
@@ -2,9 +2,10 @@ import { PageParam, PaginationResult, Result } from 'global/type'
 import { TaskCard } from './taskCard.entity'
 
 export interface TaskCardRepository {
-  create(data: Pick<TaskCard, 'name' | 'description'>): Promise<TaskCard>
+  create(data: Pick<TaskCard, 'name' | 'description' | 'created_by_id'>): Promise<TaskCard>
   getList(
-    option?: Partial<Pick<TaskCard, 'name' | 'description' | 'is_closed'>> & PageParam
+    option?: Partial<Pick<TaskCard, 'name' | 'description' | 'is_closed' | 'created_by_id'>> &
+      PageParam
   ): Promise<Result<TaskCard> | PaginationResult<TaskCard>>
   getOne({ id }: Pick<TaskCard, 'id'>): Promise<TaskCard | null>
   updateOne(

--- a/backend/src/infra/mysql/dataSource.ts
+++ b/backend/src/infra/mysql/dataSource.ts
@@ -1,11 +1,5 @@
 import { DataSource } from 'typeorm'
-import config from '../../config'
-
-import { Article } from 'domain/article/article.entity'
-import { ArticleHistory } from 'domain/article/articleHistory.entity'
-import { User } from 'domain/user/user.entity'
-import { TaskCard } from 'domain/taskCard/taskCard.entity'
-import { Task } from 'domain/task/task.entity'
+import config from 'config'
 
 const dataSource = new DataSource({
   type: 'mysql',
@@ -17,9 +11,9 @@ const dataSource = new DataSource({
   timezone: '+09:00',
   synchronize: true,
   logging: true,
-  entities: [User, Article, ArticleHistory, TaskCard, Task],
-  subscribers: [],
-  migrations: [],
+  entities: ['../**/*.entity.ts'],
+  migrationsTableName: 'migrations',
+  migrations: ['../**/migrations/*.ts'],
 })
 
 export default dataSource

--- a/backend/src/infra/swagger/schemas/article.schema.yaml
+++ b/backend/src/infra/swagger/schemas/article.schema.yaml
@@ -28,7 +28,7 @@ properties:
     type: string
     format: date-time
     example: 2023-02-21T07:54:39.312Z
-  writer_id:
+  created_by_id:
     type: string
     format: uuid
     example: f1b00933-e51d-4f7f-bdf1-03016f3dd96b

--- a/backend/src/infra/swagger/schemas/taskCard.schema.yaml
+++ b/backend/src/infra/swagger/schemas/taskCard.schema.yaml
@@ -16,3 +16,7 @@ properties:
     type: number
   completed_task_count:
     type: number
+  created_by_id:
+    type: string
+    format: uuid
+    example: f1b00933-e51d-4f7f-bdf1-03016f3dd96b

--- a/backend/src/migrations/1685377084798-change_column_name_from_writer_id_to_created_by.ts
+++ b/backend/src/migrations/1685377084798-change_column_name_from_writer_id_to_created_by.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ChangeColumnNameFromWriterIdToCreatedBy1685377084798 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE article RENAME COLUMN writer_id TO created_by_id;`)
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE article RENAME COLUMN created_by_id TO writer_id;`)
+  }
+}

--- a/backend/src/migrations/1685867738027-add_created_by_id_column_to_task_card_table.ts
+++ b/backend/src/migrations/1685867738027-add_created_by_id_column_to_task_card_table.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddCreatedByIdColumnToTaskCardTable1685867738027 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE task_card ADD created_by_id VARBINARY(16);')
+    await queryRunner.query(
+      'ALTER TABLE task_card ADD CONSTRAINT FK_TaskCardCreatedById FOREIGN KEY (created_by_id) REFERENCES user (user_id);'
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE article DROP COLUMN created_by_id;')
+    await queryRunner.query('ALTER TABLE task_card DROP FOREIGN KEY FK_TaskCardCreatedById;')
+  }
+}

--- a/backend/src/repository/article.repository.impl.ts
+++ b/backend/src/repository/article.repository.impl.ts
@@ -33,8 +33,8 @@ class ArticleRepositoryImpl implements ArticleRepository {
     if (option?.short_description) {
       query.where({ short_description: Like(`%${option.short_description}%`) })
     }
-    if (option?.writer_id) {
-      query.where({ writer_id: option.writer_id })
+    if (option?.created_by_id) {
+      query.where({ created_by_id: option.created_by_id })
     }
 
     if (option?.page) {

--- a/backend/src/repository/taskCard.repository.impl.ts
+++ b/backend/src/repository/taskCard.repository.impl.ts
@@ -29,6 +29,9 @@ class TaskCardRepositoryImpl implements TaskCardRepository {
     if (option?.description) {
       query.where({ description: Like(`%${option.description}%`) })
     }
+    if (option?.created_by_id) {
+      query.where({ created_by_id: option.created_by_id })
+    }
 
     if (option?.page) {
       return await paginate<TaskCard>({ query, page: option.page, page_size: option.page_size })

--- a/backend/src/services/article.service.ts
+++ b/backend/src/services/article.service.ts
@@ -16,20 +16,20 @@ class ArticleService {
     content,
     thumbnail,
     short_description,
-    writer_id,
+    created_by_id,
   }: {
     title: string
     thumbnail?: string
     short_description?: string
     content: string
-    writer_id: string
+    created_by_id: string
   }) {
     const article = new Article({
       title,
       content,
       thumbnail,
       short_description,
-      writer_id,
+      created_by_id,
     })
 
     return await this.articleRepository.create(article)
@@ -40,17 +40,19 @@ class ArticleService {
     content,
     thumbnail,
     short_description,
-    writer_id,
+    created_by_id,
     page,
     page_size,
-  }: Partial<Pick<Article, 'title' | 'content' | 'thumbnail' | 'short_description' | 'writer_id'>> &
+  }: Partial<
+    Pick<Article, 'title' | 'content' | 'thumbnail' | 'short_description' | 'created_by_id'>
+  > &
     PageParam) {
     return await this.articleRepository.getList({
       title,
       content,
       thumbnail,
       short_description,
-      writer_id,
+      created_by_id,
       page,
       page_size,
     })

--- a/backend/src/services/taskCard.service.ts
+++ b/backend/src/services/taskCard.service.ts
@@ -6,21 +6,27 @@ import { CustomError } from 'global/utils'
 class TaskCardService {
   constructor(private taskCardRepository: TaskCardRepository) {}
 
-  public async createTaskCard(taskCard: Pick<TaskCard, 'name' | 'description'>) {
-    return await this.taskCardRepository.create(taskCard)
+  public async createTaskCard({
+    name,
+    description,
+    created_by_id,
+  }: Parameters<TaskCardRepository['create']>[0]) {
+    return await this.taskCardRepository.create({ name, description, created_by_id })
   }
 
   public async getTaskCards({
     name,
     description,
     is_closed,
+    created_by_id,
     page,
     page_size,
-  }: Partial<Pick<TaskCard, 'name' | 'description' | 'is_closed'>> & PageParam) {
+  }: Partial<Pick<TaskCard, 'name' | 'description' | 'is_closed' | 'created_by_id'>> & PageParam) {
     return await this.taskCardRepository.getList({
       name,
       description,
       is_closed,
+      created_by_id,
       page,
       page_size,
     })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     volumes:
       - ./backend/src:/usr/src/app/src
       - ./backend/uploads:/usr/src/app/uploads
+      - ./backend/package.json:/usr/src/app/package.json
       - /usr/src/app/node_modules
     depends_on:
       - mysql

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -7,7 +7,7 @@ const App = () => {
   const { CustomSnackbar } = useSnackbar()
 
   return (
-    <div className="w-screen h-screen">
+    <div className="w-screen min-h-screen">
       <CustomSnackbar />
 
       <PageRouter />

--- a/frontend/src/app/Layout/components/AppBar.tsx
+++ b/frontend/src/app/Layout/components/AppBar.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material'
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar'
-import { drawerWidth } from '../contant'
+import { DRAWER_WIDTH } from '../contant'
 
 interface AppBarProps extends MuiAppBarProps {
   open?: boolean
@@ -19,8 +19,8 @@ const AppBar = styled(MuiAppBar, {
   backdropFilter: 'blur(7px)',
   backgroundColor: 'rgba(255, 255, 255, 0.7)',
   ...(open && {
-    marginLeft: drawerWidth,
-    width: `calc(100% - ${drawerWidth}px)`,
+    marginLeft: DRAWER_WIDTH,
+    width: `calc(100% - ${DRAWER_WIDTH}px)`,
     transition: theme.transitions.create(['width', 'margin'], {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,

--- a/frontend/src/app/Layout/components/Drawer.tsx
+++ b/frontend/src/app/Layout/components/Drawer.tsx
@@ -1,9 +1,9 @@
 import { CSSObject, styled, Theme } from '@mui/material'
 import MuiDrawer from '@mui/material/Drawer'
-import { drawerWidth } from '../contant'
+import { DRAWER_WIDTH } from '../contant'
 
 const openedMixin = (theme: Theme): CSSObject => ({
-  width: drawerWidth,
+  width: DRAWER_WIDTH,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.enteringScreen,
@@ -25,7 +25,7 @@ const closedMixin = (theme: Theme): CSSObject => ({
 
 const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' })(
   ({ theme, open }) => ({
-    width: drawerWidth,
+    width: DRAWER_WIDTH,
     flexShrink: 0,
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',

--- a/frontend/src/app/Layout/contant.ts
+++ b/frontend/src/app/Layout/contant.ts
@@ -1,1 +1,1 @@
-export const drawerWidth = 240
+export const DRAWER_WIDTH = 240

--- a/frontend/src/app/Layout/index.tsx
+++ b/frontend/src/app/Layout/index.tsx
@@ -174,7 +174,7 @@ const PageLayout: React.FC<PageLayoutProps> = ({ children }) => {
         </List>
       </Drawer>
 
-      <Box component="main" className="!p-0 bg-background" sx={{ flexGrow: 1, p: 3 }}>
+      <Box component="main" className="!p-0 bg-background min-h-screen" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
         {children}
       </Box>

--- a/frontend/src/article/ArticleDetail/index.tsx
+++ b/frontend/src/article/ArticleDetail/index.tsx
@@ -58,13 +58,14 @@ const ArticleDetail: React.FC = () => {
 
             <Divider className="!my-4" />
 
-            <MDEditor.Markdown
-              source={article.content}
-              style={{
-                whiteSpace: 'pre-wrap',
-                padding: '1rem',
-              }}
-            />
+            <div className="p-6 bg-white rounded-lg">
+              <MDEditor.Markdown
+                source={article.content}
+                style={{
+                  padding: '8',
+                }}
+              />
+            </div>
           </>
         )}
       </div>

--- a/frontend/src/article/ArticleEditor/Editor.tsx
+++ b/frontend/src/article/ArticleEditor/Editor.tsx
@@ -111,7 +111,7 @@ const Editor: React.FC<EditorProps> = ({
       <MDEditor
         value={content}
         onChange={(value) => setContent(value || '')}
-        height={400}
+        height="65vh"
         onPaste={async (event) => {
           if (event.clipboardData.files.length) {
             event.preventDefault()

--- a/frontend/src/article/api/entity.ts
+++ b/frontend/src/article/api/entity.ts
@@ -4,7 +4,7 @@ export interface Article {
   content: string
   thumbnail?: string
   short_description?: string
-  writer_id: string
+  created_by_id: string
   created_at: string // timestamp
   updated_at: string // timestamp
 }

--- a/frontend/src/auth/Login.tsx
+++ b/frontend/src/auth/Login.tsx
@@ -52,7 +52,7 @@ const Login = () => {
   )
 
   return (
-    <div className="w-full h-full flex justify-center items-center">
+    <div className="w-full h-screen flex justify-center items-center">
       <div className="w-[350px] h-[50vh] flex flex-col justify-center">
         <div className="flex items-center justify-between">
           <Typography variant="h5" gutterBottom className="!font-semibold">

--- a/frontend/src/auth/Signup.tsx
+++ b/frontend/src/auth/Signup.tsx
@@ -90,7 +90,7 @@ const Signup = () => {
   )
 
   return (
-    <div className="w-full h-full flex justify-center items-center">
+    <div className="w-full h-screen flex justify-center items-center">
       <div className="w-[350px] h-[50vh] flex flex-col justify-center">
         <div className="flex items-center justify-between">
           <Typography variant="h5" gutterBottom className="!font-semibold">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,7 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  ul,
+  ol {
+    list-style: revert;
+  }
+}
+
 * {
   box-sizing: border-box;
-  letter-spacing: -0.015em !important;
+  /* letter-spacing: -0.015em !important; */
 }

--- a/frontend/src/task/TaskCardList/EditTaskCardModal.tsx
+++ b/frontend/src/task/TaskCardList/EditTaskCardModal.tsx
@@ -26,10 +26,10 @@ const EditTaskCardModal: React.FC<EditTaskCardModalProps> = ({
   const [input, setInput] = useState<typeof taskCard>(taskCard)
 
   return (
-    <Dialog open={isOpen} onClose={close}>
+    <Dialog open={isOpen} onClose={close} maxWidth="xl">
       <DialogTitle>{taskCard ? '태스크 카드 수정' : '태스크 카드 추가'}</DialogTitle>
 
-      <DialogContent>
+      <DialogContent className="w-[50vw]">
         <TextField
           autoFocus
           margin="dense"

--- a/frontend/src/task/TaskCardList/TaskListDrawer/EditTaskModal.tsx
+++ b/frontend/src/task/TaskCardList/TaskListDrawer/EditTaskModal.tsx
@@ -13,10 +13,10 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({ isOpen, close, submit, ta
   const [input, setInput] = useState<Pick<Task, 'content'> | undefined>(task)
 
   return (
-    <Dialog open={isOpen} onClose={close}>
+    <Dialog open={isOpen} onClose={close} maxWidth="xl">
       <DialogTitle>{task ? '태스크 수정' : '태스크 추가'}</DialogTitle>
 
-      <DialogContent>
+      <DialogContent className="w-[50vw]">
         <TextField
           autoFocus
           margin="dense"

--- a/frontend/src/task/TaskCardList/TaskListDrawer/index.tsx
+++ b/frontend/src/task/TaskCardList/TaskListDrawer/index.tsx
@@ -122,7 +122,10 @@ const TaskListDrawer: React.FC<TaskListDrawerProps> = ({ isOpen, close, taskCard
             <TaskItem
               key={`task-item-${task.id}`}
               task={task}
-              refetch={refetchTasks}
+              refetch={() => {
+                refetchTaskCards()
+                refetchTasks()
+              }}
               foldMode={foldMode}
             />
           ))}

--- a/frontend/src/task/TaskCardList/index.tsx
+++ b/frontend/src/task/TaskCardList/index.tsx
@@ -3,10 +3,10 @@ import { IconButton, Typography } from '@mui/material'
 import { LibraryAdd as LibraryAddIcon } from '@mui/icons-material'
 
 import { useTaskCards } from '../api/hook'
+import useEditTaskCard from '../hook/useEditTaskCard'
 import TaskCircle from './TaskCircle'
 import TaskListDrawer from './TaskListDrawer'
 import EditTaskCardModal from './EditTaskCardModal'
-import useEditTaskCard from '../hook/useEditTaskCard'
 
 const TaskCardList: React.FC = () => {
   const { taskCards, refetch } = useTaskCards()


### PR DESCRIPTION
### backend
- article 테이블: `writer_id` -> `created_by_id`로 컬럼명 변경
  - migration 코드 작성
  - 관련 로직 변경
- task_card 테이블: `created_by_id` 컬럼 추가
  - migration 코드 작성
    - 현재 개발환경으로 docker container를 사용중이기 때문에, 작성한 마이그레이션 파일은 docker container 내부에서 사용함
    - 추가한 컬럼 옵션을 `NOT NULL` 로 주고싶었으나, default value를 설정하지않고 `NOT NULL` 컬럼으로 설정할 수 없었음
    - 일단 `nullable`한 컬럼으로 추가하고, 데이터(`user id`)를 직접 채워 넣은 뒤 `NOT NULL`로 컬럼 설정을 직접 변경
      - 데이터를 채워넣는 과정 또한 마이그레이션 코드로 작성할 수 있었겠지만, 특정한 데이터(`user id`)를 마이그레이션 코드로 작성하고 싶지 않았음
    - 이런 상황이 운영 환경에서 일어났다면? 1. `nullable`한 컬럼을 추가하는 마이그레이션 파일을 따로 작성하고 2. 데이터를 넣은 뒤 3. 다시 해당 컬럼을 `NOT NULL`로 변경하는 마이그레이션 파일을 작성했을 것 같음
  - 관련 로직 추가